### PR TITLE
116 add vigourpitcontrol pre processing to core functions

### DIFF
--- a/core/preprocess_data.jl
+++ b/core/preprocess_data.jl
@@ -72,7 +72,7 @@ function prepare_max_press_data(
     participant_id_column::Symbol = :participant_id
     )
 	# Define required columns for max press data
-	required_columns = [participant_id_column, :record_id, :version, :exp_start_time, :session, :trialphase, :trial_number, :avgSpeed, :responseTime, :trialPresses]
+	required_columns = [participant_id_column, :version, :module_start_time, :session, :trialphase, :trial_number, :avgSpeed, :responseTime, :trialPresses]
 
 	# Check and add missing columns
 	for col in required_columns

--- a/core/preprocess_data.jl
+++ b/core/preprocess_data.jl
@@ -184,8 +184,12 @@ function prepare_control_data(df::DataFrame;
         parsed = map(row -> begin
                 ismissing(row.timeline_variables) && return Dict()
                 str = startswith(row.timeline_variables, "{") ? row.timeline_variables : "{" * row.timeline_variables
-                try JSON.parse(str) catch; Dict() end
-        end, eachrow(df))
+                try
+                    JSON.parse(str)
+                catch e
+                    @warn "Failed to parse JSON in timeline_variables" exception=(e, catch_backtrace()) value=str
+                    Dict()
+                end
         
         for key in unique(Iterators.flatten(keys.(parsed)))
                 df[!, key] = [get(p, key, missing) for p in parsed]

--- a/core/preprocess_data.jl
+++ b/core/preprocess_data.jl
@@ -225,6 +225,8 @@ function prepare_control_data(df::DataFrame;
 	control_feedback_data = filter(row -> row.trialphase ∈ ["control_explore_feedback", "control_reward_feedback"], control_data)
 	control_feedback_data = control_feedback_data[:, .!all.(ismissing, eachcol(control_feedback_data))]
 
+	sort!(control_task_data, [:module_start_time, participant_id_column, :session, :task, :version, :trial])
+	sort!(control_feedback_data, [:module_start_time, participant_id_column, :session, :task, :version, :trial])
 	merged_control = outerjoin(control_task_data, control_feedback_data, on=[:module_start_time, participant_id_column, :session, :task, :version, :trial], source=:source, makeunique=true, order=:left)
 	if "correct_1" in names(merged_control)
 		transform!(merged_control, [:correct, :correct_1] => ((x, y) -> coalesce.(x, y)) => :correct)


### PR DESCRIPTION
This pull request significantly expands and refines the data preprocessing capabilities in `core/preprocess_data.jl` by adding new functions for handling different experimental tasks and updating existing logic to support these new workflows. The changes introduce dedicated preprocessing functions for the "vigour", "PIT", and "control" tasks, and ensure these are integrated into the main task preprocessing dispatch. Additionally, there is a small update to the required columns for "max_press" data.

Close #116 

**New data preparation functions:**

* Added `prepare_vigour_data`, `prepare_PIT_data`, and `prepare_control_data` functions to preprocess data for the respective tasks, including robust handling of missing columns, JSON parsing, and column extraction. (`[core/preprocess_data.jlR112-R240](diffhunk://#diff-883b259bd12b47e85243b3556cf8b3fc384801afca6f272a76c6d8106e68fd10R112-R240)`)

**Integration with task preprocessing:**

* Registered the new data preparation functions in the `TASK_PREPROC_FUNCS` dictionary, enabling automatic preprocessing for the "vigour", "PIT", and "control" tasks. (`[core/preprocess_data.jlL120-R252](diffhunk://#diff-883b259bd12b47e85243b3556cf8b3fc384801afca6f272a76c6d8106e68fd10L120-R252)`)

**Updates to existing data preparation:**

* Updated the required columns in `prepare_max_press_data` to use `:module_start_time` instead of `:exp_start_time`, and removed `:record_id` to align with new data standards. (`[core/preprocess_data.jlL75-R75](diffhunk://#diff-883b259bd12b47e85243b3556cf8b3fc384801afca6f272a76c6d8106e68fd10L75-R75)`)